### PR TITLE
Switch to -> literal lambda for multiline too

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,8 @@ Style/HashTransformKeys:
   Enabled: false
 Style/HashTransformValues:
   Enabled: true
+Style/Lambda:
+  EnforcedStyle: literal
 Style/ModuleFunction:
   Enabled: false
 Style/MultilineTernaryOperator:


### PR DESCRIPTION
Not sure why the default is to use the `lambda` keyword for multiline lambdas. Using `->` consistently seems far preferable to me.